### PR TITLE
Add tab completion and Copilot support for Markdown in VSCode settings

### DIFF
--- a/home/programs/dev.nix
+++ b/home/programs/dev.nix
@@ -31,10 +31,16 @@
       ];
 
       userSettings = {
-        editor.formatOnSave = true;
+        editor = {
+          formatOnSave = true;
+          rulers = [ 80 120];
+          tabCompletion = "on";
+        };
         git.confirmSync = false;
         window.titleBarStyle = "custom";
-        editor.rulers = [ 80 120];
+        github.copilot.enable = {
+          markdown = true;
+        };
       };
     };
   };


### PR DESCRIPTION
Introduce tab completion and enable GitHub Copilot for Markdown in the VSCode user settings.